### PR TITLE
Add note to ignore reqs if banned automatically or for scams

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,21 +8,32 @@
         <link href="https://fonts.googleapis.com/css2?family=Fira+Sans&display=swap" rel="stylesheet">
         <link rel="stylesheet" href="style.css">
 
-        <title>Microsoft Community ban appeal</title>
+        <title>Ban Appeal - Microsoft Community</title>
     </head>
     <body class="h-100 d-flex flex-column justify-content-center align-items-stretch">
         <div class="jumbotron text-center mb-0">
-            <h1>Microsoft Community ban appeal</h1>
+            <h1>Ban Appeal</h1>
+            <h2>Microsoft Community</h2>
+            <div class="text-center margin-auto d-inline-block mt-4">
+                <p>To appeal your ban, you will need to meet the following requirements:</p>
+                <p>
+                    <ul class="text-left d-inline-block" style="color: #b9bbbe">
+                        <li>At least 120 days have passed since you were banned.</li>
+                        <li>You understand and are able to explain why you were banned.</li>
+                    </ul>
+                </p>
+                <p>This is to make sure you've had the time to reflect on your actions, realise that there was justifiable reason for your ban and help you<br>acknowledge your mistake. These requirements are enforced for almost all appeals, though rare exceptions may be made for some special cases.</p>
+                <p style="font-weight: bold">
+                    Note: if you were automatically banned for "matching patterns of known raiders", or banned
+                    <br>for reasons similar to "nitro scam, compromised account", you may appeal immediately
+                    <br>and disregard the requirements listed above.
+                </p>
+            </div>
         </div>
-
+    
         <div class="flex-fill text-center d-flex flex-column h-100 justify-content-center align-items-center">
             <div class="text-light">
-                <h3>Appeal requirements:</h3>
-                <ul class="text-left">
-                    <li>120 days passed since you were banned.</li>
-                    <li>Being able to explain why you were banned, that shows us that you understand that you weren't banned for no reason and acknowledge your mistake.</li>
-                </ul>
-                <p>These requirements are enforced in the majority of cases, though rare exceptions may be made for some special cases.</p>
+               <p><h4>Once you've read the requirements above, click below to start your appeal.</h4></p>
             </div>
             <a class="btn" id="login" style="font-size: 2rem;" href="/api/oauth">Login with Discord</a>
         </div>


### PR DESCRIPTION
Adds a note under the requirements to ignore them if banned automatically (for matching raid patterns, etc.) or if banned for account compromise (reasons such as `nitro scam, compromised account`).

Note: this PR includes the changes proposed in PR #1.